### PR TITLE
[DO NOT MERGE] Add a kubevirt host and start a VM on it

### DIFF
--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/hostdeploy/InstallVdsInternalCommand.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/hostdeploy/InstallVdsInternalCommand.java
@@ -205,12 +205,14 @@ public class InstallVdsInternalCommand<T extends InstallVdsParameters> extends V
                             auditLogDirector)) {
                         if (detector.shouldCheckProtocolTofallback()) {
                             // we need to check whether we are connecting to vdsm which supports xmlrpc only
-                            if (!detector.attemptConnection()) {
-                                detector.stopConnection();
-                                if (detector.attemptFallbackProtocol()) {
-                                    detector.setFallbackProtocol();
-                                } else {
-                                    throw new VdsInstallException(VDSStatus.InstallFailed, "Host is not reachable");
+                            if (!detector.attemptKubevirtConnection()) {
+                                if (!detector.attemptConnection()) {
+                                    detector.stopConnection();
+                                    if (detector.attemptFallbackProtocol()) {
+                                        detector.setFallbackProtocol();
+                                    } else {
+                                        throw new VdsInstallException(VDSStatus.InstallFailed, "Host is not reachable");
+                                    }
                                 }
                             }
                         }

--- a/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/transport/ProtocolDetector.java
+++ b/backend/manager/modules/bll/src/main/java/org/ovirt/engine/core/bll/transport/ProtocolDetector.java
@@ -69,6 +69,7 @@ public class ProtocolDetector implements AutoCloseable {
      * @return <code>true</code> if connected or <code>false</code> if connection failed.
      */
     public boolean attemptConnection() {
+
         boolean connected = false;
         try {
             for (int i = 0; i < this.retryAttempts; i++) {
@@ -89,6 +90,16 @@ public class ProtocolDetector implements AutoCloseable {
             log.debug("Exception", e);
         }
         return connected;
+    }
+
+    public boolean attemptKubevirtConnection() {
+        //TODO Kubevirt do something reasonable here
+        if (vds.getName().startsWith("kubevirt")) {
+            vds.setProtocol(VdsProtocol.KUBEVIRT);
+            resourceManager.AddVds(vds, false);
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VdsProtocol.java
+++ b/backend/manager/modules/common/src/main/java/org/ovirt/engine/core/common/businessentities/VdsProtocol.java
@@ -9,7 +9,8 @@ import java.util.Map;
  */
 public enum VdsProtocol {
     XML(0),
-    STOMP(1);
+    STOMP(1),
+    KUBEVIRT(2);
 
     private static final Map<Integer, VdsProtocol> MAPPING = new HashMap<Integer, VdsProtocol>();
     static {

--- a/backend/manager/modules/vdsbroker/pom.xml
+++ b/backend/manager/modules/vdsbroker/pom.xml
@@ -65,7 +65,14 @@
       <artifactId>commons-httpclient</artifactId>
     </dependency>
 
-    <dependency>
+      <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+          <version>4.5.2</version>
+      </dependency>
+
+
+      <dependency>
        <groupId>org.codehaus.jackson</groupId>
        <artifactId>jackson-core-asl</artifactId>
        <version>${jackson.version}</version>

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/TransportFactory.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/TransportFactory.java
@@ -7,7 +7,9 @@ import org.ovirt.engine.core.common.businessentities.VdsProtocol;
 import org.ovirt.engine.core.common.config.Config;
 import org.ovirt.engine.core.common.config.ConfigValues;
 import org.ovirt.engine.core.common.utils.Pair;
+import org.ovirt.engine.core.compat.Guid;
 import org.ovirt.engine.core.compat.Version;
+import org.ovirt.engine.core.di.Injector;
 import org.ovirt.engine.core.vdsbroker.irsbroker.IIrsServer;
 import org.ovirt.engine.core.vdsbroker.irsbroker.IrsServerConnector;
 import org.ovirt.engine.core.vdsbroker.irsbroker.IrsServerWrapper;
@@ -17,10 +19,14 @@ import org.ovirt.engine.core.vdsbroker.jsonrpc.JsonRpcVdsServer;
 import org.ovirt.engine.core.vdsbroker.vdsbroker.IVdsServer;
 import org.ovirt.engine.core.vdsbroker.vdsbroker.VdsServerConnector;
 import org.ovirt.engine.core.vdsbroker.vdsbroker.VdsServerWrapper;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.kubevirt.KubevirtIrsServer;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.kubevirt.KubevirtVdsServer;
 import org.ovirt.engine.core.vdsbroker.xmlrpc.XmlRpcUtils;
 
 public class TransportFactory {
-    public static IIrsServer createIrsServer(VdsProtocol vdsProtocol,
+    public static IIrsServer createIrsServer(
+            Guid vdsId,
+            VdsProtocol vdsProtocol,
             Version version,
             String hostname,
             int port,
@@ -46,11 +52,15 @@ public class TransportFactory {
                             Config.<Integer> getValue(ConfigValues.MaxTotalConnections),
                             IrsServerConnector.class, Config.<Boolean> getValue(ConfigValues.EncryptHostCommunication));
             irsServer = new IrsServerWrapper(returnValue.getFirst(), returnValue.getSecond());
+        } else if (VdsProtocol.KUBEVIRT == vdsProtocol) {
+            irsServer = Injector.injectMembers(new KubevirtIrsServer(vdsId));
         }
         return irsServer;
     }
 
-    public static IVdsServer createVdsServer(VdsProtocol vdsProtocol,
+    public static IVdsServer createVdsServer(
+            Guid vdsId,
+            VdsProtocol vdsProtocol,
             Version version,
             String hostname,
             int port,
@@ -83,6 +93,8 @@ public class TransportFactory {
             String protocol = Config.<Boolean> getValue(ConfigValues.EncryptHostCommunication) ? "https" : "http";
             httpClient.getHostConfiguration().setHost(hostname, port, Protocol.getProtocol(protocol));
             vdsServer = new VdsServerWrapper(returnValue.getFirst(), httpClient);
+        } else if (VdsProtocol.KUBEVIRT == vdsProtocol) {
+            return Injector.injectMembers(new KubevirtVdsServer(vdsId));
         }
         return vdsServer;
     }

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/VdsManager.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/VdsManager.java
@@ -188,6 +188,7 @@ public class VdsManager {
         int heartbeat = Config.<Integer> getValue(ConfigValues.vdsHeartbeatInSeconds) * 1000;
         int clientRetries = Config.<Integer> getValue(ConfigValues.vdsRetries);
         vdsProxy = TransportFactory.createVdsServer(
+                cachedVds.getId(),
                 cachedVds.getProtocol(),
                 cachedVds.getVdsGroupCompatibilityVersion(),
                 cachedVds.getHostName(),

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/irsbroker/IrsProxyData.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/irsbroker/IrsProxyData.java
@@ -642,7 +642,9 @@ public class IrsProxyData {
                     int connectionTimeOut = Config.<Integer> getValue(ConfigValues.vdsConnectionTimeout) * 1000;
                     int heartbeat = Config.<Integer> getValue(ConfigValues.vdsHeartbeatInSeconds) * 1000;
                     int clientRetries = Config.<Integer> getValue(ConfigValues.vdsRetries);
-                    irsProxy = TransportFactory.createIrsServer(getProtocol(),
+                    irsProxy = TransportFactory.createIrsServer(
+                            getCurrentVdsId(),
+                            getProtocol(),
                                     getVersion(),
                                     host,
                                     getmIrsPort(),

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/kubevirt/EnvServiceDiscovery.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/kubevirt/EnvServiceDiscovery.java
@@ -1,0 +1,26 @@
+package org.ovirt.engine.core.vdsbroker.vdsbroker.kubevirt;
+
+import java.util.Objects;
+
+import org.ovirt.engine.core.compat.Guid;
+
+/**
+ * Implementation mostly for testing purposes when running everything on a single node.
+ */
+public class EnvServiceDiscovery implements ServiceDiscovery {
+
+    @Override
+    public String discover(String serviceName) {
+        Objects.requireNonNull(serviceName);
+        String host = System.getenv(serviceName.toUpperCase() + "_SERVICE_HOST");
+        String port = System.getenv(serviceName.toUpperCase() + "_SERVICE_PORT");
+        return String.format("http://%s:%s", host, port);
+    }
+
+    @Override
+    public String discover(String serviceName, Guid vdsId) {
+        Objects.requireNonNull(serviceName);
+        Objects.requireNonNull(vdsId);
+        return discover(serviceName);
+    }
+}

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/kubevirt/HttpClientConnectionFactory.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/kubevirt/HttpClientConnectionFactory.java
@@ -1,0 +1,34 @@
+package org.ovirt.engine.core.vdsbroker.vdsbroker.kubevirt;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.inject.Produces;
+import javax.inject.Singleton;
+
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+
+@Singleton
+public class HttpClientConnectionFactory {
+    private PoolingHttpClientConnectionManager connectionManager;
+
+    public HttpClientConnectionFactory() {
+
+    }
+
+    @PostConstruct
+    public void init() {
+        connectionManager = new PoolingHttpClientConnectionManager();
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        connectionManager.close();
+    }
+
+    @Produces @Singleton
+    public CloseableHttpClient get() {
+        return HttpClients.custom().setConnectionManager(connectionManager).build();
+    }
+}

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/kubevirt/KubevirtIrsServer.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/kubevirt/KubevirtIrsServer.java
@@ -1,0 +1,309 @@
+package org.ovirt.engine.core.vdsbroker.vdsbroker.kubevirt;
+
+import java.util.Map;
+
+import org.ovirt.engine.core.compat.Guid;
+import org.ovirt.engine.core.vdsbroker.irsbroker.FileStatsReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.irsbroker.GetVmsInfoReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.irsbroker.IIrsServer;
+import org.ovirt.engine.core.vdsbroker.irsbroker.ImagesListReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.irsbroker.IrsStatsAndStatusXmlRpc;
+import org.ovirt.engine.core.vdsbroker.irsbroker.OneImageInfoReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.irsbroker.OneUuidReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.irsbroker.StoragePoolInfoReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.irsbroker.StorageStatusReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.irsbroker.UUIDListReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.irsbroker.VolumeListReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.ResizeStorageDomainPVMapReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.StatusOnlyReturnForXmlRpc;
+
+public class KubevirtIrsServer implements IIrsServer {
+
+    private final Guid vdsId;
+
+    public KubevirtIrsServer(Guid vdsId) {
+        this.vdsId = vdsId;
+
+    }
+
+    @Override
+    public OneUuidReturnForXmlRpc createVolume(String sdUUID,
+            String spUUID,
+            String imgGUID,
+            String size,
+            int volFormat,
+            int volType,
+            int diskType,
+            String volUUID,
+            String descr,
+            String srcImgGUID,
+            String srcVolUUID) {
+        return null;
+    }
+
+    @Override
+    public OneUuidReturnForXmlRpc createVolume(String sdUUID,
+            String spUUID,
+            String imgGUID,
+            String size,
+            int volFormat,
+            int volType,
+            int diskType,
+            String volUUID,
+            String descr,
+            String srcImgGUID,
+            String srcVolUUID,
+            String initialSize) {
+        return null;
+    }
+
+    @Override
+    public OneUuidReturnForXmlRpc copyImage(String sdUUID,
+            String spUUID,
+            String vmGUID,
+            String srcImgGUID,
+            String srcVolUUID,
+            String dstImgGUID,
+            String dstVolUUID,
+            String descr,
+            String dstSdUUID,
+            int volType,
+            int volFormat,
+            int preallocate,
+            String postZero,
+            String force) {
+        return null;
+    }
+
+    @Override
+    public OneUuidReturnForXmlRpc downloadImage(Map methodInfo,
+            String spUUID,
+            String sdUUID,
+            String dstImgGUID,
+            String dstVolUUID) {
+        return null;
+    }
+
+    @Override
+    public OneUuidReturnForXmlRpc uploadImage(Map methodInfo,
+            String spUUID,
+            String sdUUID,
+            String srcImgGUID,
+            String srcVolUUID) {
+        return null;
+    }
+
+    @Override
+    public OneUuidReturnForXmlRpc mergeSnapshots(String sdUUID,
+            String spUUID,
+            String vmGUID,
+            String imgGUID,
+            String ancestorUUID,
+            String successorUUID,
+            String postZero) {
+        return null;
+    }
+
+    @Override
+    public VolumeListReturnForXmlRpc reconcileVolumeChain(String spUUID,
+            String sdUUID,
+            String imgGUID,
+            String leafVolUUID) {
+        return null;
+    }
+
+    @Override
+    public OneUuidReturnForXmlRpc deleteVolume(String sdUUID,
+            String spUUID,
+            String imgGUID,
+            String[] volUUID,
+            String postZero,
+            String force) {
+        return null;
+    }
+
+    @Override
+    public OneImageInfoReturnForXmlRpc getVolumeInfo(String sdUUID, String spUUID, String imgGUID, String volUUID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc setVolumeDescription(String sdUUID,
+            String spUUID,
+            String imgGUID,
+            String volUUID,
+            String description) {
+        return null;
+    }
+
+    @Override
+    public IrsStatsAndStatusXmlRpc getIrsStats() {
+        return null;
+    }
+
+    @Override
+    public FileStatsReturnForXmlRpc getIsoList(String spUUID) {
+        return null;
+    }
+
+    @Override
+    public FileStatsReturnForXmlRpc getFloppyList(String spUUID) {
+        return null;
+    }
+
+    @Override
+    public FileStatsReturnForXmlRpc getFileStats(String sdUUID, String pattern, boolean caseSensitive) {
+        return null;
+    }
+
+    @Override
+    public StorageStatusReturnForXmlRpc activateStorageDomain(String sdUUID, String spUUID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc deactivateStorageDomain(String sdUUID,
+            String spUUID,
+            String msdUUID,
+            int masterVersion) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc detachStorageDomain(String sdUUID,
+            String spUUID,
+            String msdUUID,
+            int masterVersion) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc forcedDetachStorageDomain(String sdUUID, String spUUID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc attachStorageDomain(String sdUUID, String spUUID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc setStorageDomainDescription(String sdUUID, String description) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc extendStorageDomain(String sdUUID, String spUUID, String[] devlist) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc extendStorageDomain(String sdUUID,
+            String spUUID,
+            String[] devlist,
+            boolean force) {
+        return null;
+    }
+
+    @Override
+    public ResizeStorageDomainPVMapReturnForXmlRpc resizeStorageDomainPV(String sdUUID, String spUUID, String device) {
+        return null;
+    }
+
+    @Override
+    public StoragePoolInfoReturnForXmlRpc getStoragePoolInfo(String spUUID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc destroyStoragePool(String spUUID, int hostSpmId, String SCSIKey) {
+        return null;
+    }
+
+    @Override
+    public OneUuidReturnForXmlRpc deleteImage(String sdUUID,
+            String spUUID,
+            String imgGUID,
+            String postZero,
+            String force) {
+        return null;
+    }
+
+    @Override
+    public OneUuidReturnForXmlRpc moveImage(String spUUID,
+            String srcDomUUID,
+            String dstDomUUID,
+            String imgGUID,
+            String vmGUID,
+            int op,
+            String postZero,
+            String force) {
+        return null;
+    }
+
+    @Override
+    public OneUuidReturnForXmlRpc cloneImageStructure(String spUUID,
+            String srcDomUUID,
+            String imgGUID,
+            String dstDomUUID) {
+        return null;
+    }
+
+    @Override
+    public OneUuidReturnForXmlRpc syncImageData(String spUUID,
+            String srcDomUUID,
+            String imgGUID,
+            String dstDomUUID,
+            String syncType) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc updateVM(String spUUID, Map[] vms) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc removeVM(String spUUID, String vmGUID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc updateVMInImportExport(String spUUID, Map[] vms, String StorageDomainId) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc removeVM(String spUUID, String vmGUID, String storageDomainId) {
+        return null;
+    }
+
+    @Override
+    public GetVmsInfoReturnForXmlRpc getVmsInfo(String storagePoolId, String storageDomainId, String[] VMIDList) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc upgradeStoragePool(String storagePoolId, String targetVersion) {
+        return null;
+    }
+
+    @Override
+    public ImagesListReturnForXmlRpc getImagesList(String sdUUID) {
+        return null;
+    }
+
+    @Override
+    public UUIDListReturnForXmlRpc getVolumesList(String sdUUID, String spUUID, String imgUUID) {
+        return null;
+    }
+
+    @Override
+    public OneUuidReturnForXmlRpc extendVolumeSize(String spUUID,
+            String sdUUID,
+            String imageUUID,
+            String volumeUUID,
+            String newSize) {
+        return null;
+    }
+}

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/kubevirt/KubevirtIrsServer.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/kubevirt/KubevirtIrsServer.java
@@ -2,6 +2,9 @@ package org.ovirt.engine.core.vdsbroker.vdsbroker.kubevirt;
 
 import java.util.Map;
 
+import javax.inject.Inject;
+
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.ovirt.engine.core.compat.Guid;
 import org.ovirt.engine.core.vdsbroker.irsbroker.FileStatsReturnForXmlRpc;
 import org.ovirt.engine.core.vdsbroker.irsbroker.GetVmsInfoReturnForXmlRpc;
@@ -20,6 +23,12 @@ import org.ovirt.engine.core.vdsbroker.vdsbroker.StatusOnlyReturnForXmlRpc;
 public class KubevirtIrsServer implements IIrsServer {
 
     private final Guid vdsId;
+
+    @Inject
+    CloseableHttpClient httpClient;
+
+    @Inject
+    ServiceDiscovery serviceDiscovery;
 
     public KubevirtIrsServer(Guid vdsId) {
         this.vdsId = vdsId;

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/kubevirt/KubevirtVdsServer.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/kubevirt/KubevirtVdsServer.java
@@ -7,7 +7,10 @@ import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 
+import javax.inject.Inject;
+
 import org.apache.commons.httpclient.HttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.ovirt.engine.core.compat.Guid;
 import org.ovirt.engine.core.vdsbroker.gluster.GlusterHookContentInfoReturnForXmlRpc;
 import org.ovirt.engine.core.vdsbroker.gluster.GlusterHooksListReturnForXmlRpc;
@@ -63,6 +66,12 @@ import org.ovirt.engine.core.vdsbroker.vdsbroker.VolumeInfoReturnForXmlRpc;
 public class KubevirtVdsServer implements IVdsServer {
 
     private final Guid vdsId;
+
+    @Inject
+    CloseableHttpClient httpClient;
+
+    @Inject
+    ServiceDiscovery serviceDiscovery;
 
     public KubevirtVdsServer(Guid vdsId) {
         this.vdsId = vdsId;

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/kubevirt/KubevirtVdsServer.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/kubevirt/KubevirtVdsServer.java
@@ -1,0 +1,1131 @@
+package org.ovirt.engine.core.vdsbroker.vdsbroker.kubevirt;
+
+import java.security.cert.Certificate;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Future;
+import java.util.concurrent.FutureTask;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.ovirt.engine.core.compat.Guid;
+import org.ovirt.engine.core.vdsbroker.gluster.GlusterHookContentInfoReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.GlusterHooksListReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.GlusterHostsPubKeyReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.GlusterServersListReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.GlusterServicesReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.GlusterTaskInfoReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.GlusterTasksListReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.GlusterVolumeGeoRepConfigListXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.GlusterVolumeGeoRepStatusDetailForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.GlusterVolumeGeoRepStatusForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.GlusterVolumeOptionsInfoReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.GlusterVolumeProfileInfoReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.GlusterVolumeSnapshotConfigReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.GlusterVolumeSnapshotCreateReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.GlusterVolumeSnapshotInfoReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.GlusterVolumeStatusReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.GlusterVolumeTaskReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.GlusterVolumesListReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.OneStorageDeviceReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.gluster.StorageDeviceListReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.irsbroker.FileStatsReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.irsbroker.OneUuidReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.irsbroker.StoragePoolInfoReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.AlignmentScanReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.BooleanReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.DevicesVisibilityMapReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.FenceStatusReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.HostDevListReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.IQNListReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.IVdsServer;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.ImageSizeReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.LUNListReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.MigrateStatusReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.OneStorageDomainInfoReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.OneStorageDomainStatsReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.OneVGReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.OneVmReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.OvfReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.ServerConnectionStatusReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.SpmStatusReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.StatusOnlyReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.StorageDomainListReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.TaskInfoListReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.TaskStatusListReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.TaskStatusReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.VDSInfoReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.VGListReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.VMInfoListReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.VMListReturnForXmlRpc;
+import org.ovirt.engine.core.vdsbroker.vdsbroker.VolumeInfoReturnForXmlRpc;
+
+public class KubevirtVdsServer implements IVdsServer {
+
+    private final Guid vdsId;
+
+    public KubevirtVdsServer(Guid vdsId) {
+        this.vdsId = vdsId;
+    }
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public List<Certificate> getPeerCertificates() {
+        return null;
+    }
+
+    @Override
+    public HttpClient getHttpClient() {
+        return null;
+    }
+
+    @Override
+    public OneVmReturnForXmlRpc create(Map createInfo) {
+        // controller pod
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc createVolumeContainer(String sdUUID,
+            String imgGUID,
+            String size,
+            int volFormat,
+            int diskType,
+            String volUUID,
+            String descr,
+            String srcImgGUID,
+            String srcVolUUID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc copyData(Map src, Map dst, boolean collapse) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc allocateVolume(String spUUID,
+            String sdUUID,
+            String imgGUID,
+            String volUUID,
+            String size) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc destroy(String vmId) {
+        // controller pod
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc shutdown(String vmId, String timeout, String message) {
+        // controller pod
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc shutdown(String vmId, String timeout, String message, boolean reboot) {
+        // compute pod
+        return null;
+    }
+
+    @Override
+    public OneVmReturnForXmlRpc pause(String vmId) {
+        // compute pod
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc hibernate(String vmId, String hiberVolHandle) {
+        return null;
+    }
+
+    @Override
+    public OneVmReturnForXmlRpc resume(String vmId) {
+        return null;
+    }
+
+    @Override
+    public VMListReturnForXmlRpc list() {
+        //vAdvisor spec endpoint
+        return null;
+    }
+
+    @Override
+    public VMListReturnForXmlRpc list(String isFull, String[] vmIds) {
+        //vAdvisor spec endpoint
+        return null;
+    }
+
+    @Override
+    public VDSInfoReturnForXmlRpc getCapabilities() {
+        //hardcoded for now
+        return null;
+    }
+
+    @Override
+    public VDSInfoReturnForXmlRpc getHardwareInfo() {
+        // cAdvisor
+        return null;
+    }
+
+    @Override
+    public VDSInfoReturnForXmlRpc getVdsStats() {
+        // cAdvisor
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc setMOMPolicyParameters(Map<String, Object> key_value_store) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc setHaMaintenanceMode(String mode, boolean enabled) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc desktopLogin(String vmId, String domain, String user, String password) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc desktopLogoff(String vmId, String force) {
+        return null;
+    }
+
+    @Override
+    public VMInfoListReturnForXmlRpc getVmStats(String vmId) {
+        // prometheus
+        return null;
+    }
+
+    @Override
+    public VMInfoListReturnForXmlRpc getAllVmStats() {
+        // prometheus
+        return null;
+    }
+
+    @Override
+    public HostDevListReturnForXmlRpc hostDevListByCaps() {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc migrate(Map<String, String> migrationInfo) {
+        return null;
+    }
+
+    @Override
+    public MigrateStatusReturnForXmlRpc migrateStatus(String vmId) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc migrateCancel(String vmId) {
+        return null;
+    }
+
+    @Override
+    public OneVmReturnForXmlRpc changeDisk(String vmId, String imageLocation) {
+        return null;
+    }
+
+    @Override
+    public OneVmReturnForXmlRpc changeFloppy(String vmId, String imageLocation) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc monitorCommand(String vmId, String monitorCommand) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc setVmTicket(String vmId, String otp64, String sec) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc setVmTicket(String vmId,
+            String otp64,
+            String sec,
+            String connectionAction,
+            Map<String, String> params) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc addNetwork(String bridge,
+            String vlan,
+            String bond,
+            String[] nics,
+            Map<String, String> options) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc delNetwork(String bridge, String vlan, String bond, String[] nics) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc editNetwork(String oldBridge,
+            String newBridge,
+            String vlan,
+            String bond,
+            String[] nics,
+            Map<String, String> options) {
+        return null;
+    }
+
+    @Override
+    public Future<Map<String, Object>> setupNetworks(Map networks, Map bonding, Map options, boolean isPolicyReset) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc setSafeNetworkConfig() {
+        return null;
+    }
+
+    @Override
+    public FenceStatusReturnForXmlRpc fenceNode(String ip,
+            String port,
+            String type,
+            String user,
+            String password,
+            String action,
+            String secured,
+            String options,
+            Map<String, Object> fencingPolicy) {
+        return null;
+    }
+
+    @Override
+    public ServerConnectionStatusReturnForXmlRpc connectStorageServer(int serverType,
+            String spUUID,
+            Map<String, String>[] args) {
+        return null;
+    }
+
+    @Override
+    public ServerConnectionStatusReturnForXmlRpc disconnectStorageServer(int serverType,
+            String spUUID,
+            Map<String, String>[] args) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc createStorageDomain(int domainType,
+            String sdUUID,
+            String domainName,
+            String arg,
+            int storageType,
+            String storageFormatType) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc formatStorageDomain(String sdUUID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc connectStoragePool(String spUUID,
+            int hostSpmId,
+            String SCSIKey,
+            String masterdomainId,
+            int masterVersion,
+            Map<String, String> storageDomains) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc disconnectStoragePool(String spUUID, int hostSpmId, String SCSIKey) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc createStoragePool(int poolType,
+            String spUUID,
+            String poolName,
+            String msdUUID,
+            String[] domList,
+            int masterVersion,
+            String lockPolicy,
+            int lockRenewalIntervalSec,
+            int leaseTimeSec,
+            int ioOpTimeoutSec,
+            int leaseRetries) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc reconstructMaster(String spUUID,
+            String poolName,
+            String masterDom,
+            Map<String, String> domDict,
+            int masterVersion,
+            String lockPolicy,
+            int lockRenewalIntervalSec,
+            int leaseTimeSec,
+            int ioOpTimeoutSec,
+            int leaseRetries,
+            int hostSpmId) {
+        return null;
+    }
+
+    @Override
+    public OneStorageDomainStatsReturnForXmlRpc getStorageDomainStats(String sdUUID) {
+        return null;
+    }
+
+    @Override
+    public OneStorageDomainInfoReturnForXmlRpc getStorageDomainInfo(String sdUUID) {
+        return null;
+    }
+
+    @Override
+    public StorageDomainListReturnForXmlRpc getStorageDomainsList(String spUUID,
+            int domainType,
+            String poolType,
+            String path) {
+        return null;
+    }
+
+    @Override
+    public FileStatsReturnForXmlRpc getIsoList(String spUUID) {
+        return null;
+    }
+
+    @Override
+    public OneUuidReturnForXmlRpc createVG(String sdUUID, String[] deviceList) {
+        return null;
+    }
+
+    @Override
+    public OneUuidReturnForXmlRpc createVG(String sdUUID, String[] deviceList, boolean force) {
+        return null;
+    }
+
+    @Override
+    public VGListReturnForXmlRpc getVGList() {
+        return null;
+    }
+
+    @Override
+    public OneVGReturnForXmlRpc getVGInfo(String vgUUID) {
+        return null;
+    }
+
+    @Override
+    public LUNListReturnForXmlRpc getDeviceList(int storageType) {
+        return null;
+    }
+
+    @Override
+    public LUNListReturnForXmlRpc getDeviceList(int storageType, String[] devicesList, boolean checkStatus) {
+        return null;
+    }
+
+    @Override
+    public DevicesVisibilityMapReturnForXmlRpc getDevicesVisibility(String[] devicesList) {
+        return null;
+    }
+
+    @Override
+    public IQNListReturnForXmlRpc discoverSendTargets(Map<String, String> args) {
+        return null;
+    }
+
+    @Override
+    public OneUuidReturnForXmlRpc spmStart(String spUUID,
+            int prevID,
+            String prevLVER,
+            int recoveryMode,
+            String SCSIFencing,
+            int maxHostId,
+            String storagePoolFormatType) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc spmStop(String spUUID) {
+        return null;
+    }
+
+    @Override
+    public SpmStatusReturnForXmlRpc spmStatus(String spUUID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc refreshStoragePool(String spUUID, String msdUUID, int masterVersion) {
+        return null;
+    }
+
+    @Override
+    public TaskStatusReturnForXmlRpc getTaskStatus(String taskUUID) {
+        return null;
+    }
+
+    @Override
+    public TaskStatusListReturnForXmlRpc getAllTasksStatuses() {
+        return null;
+    }
+
+    @Override
+    public TaskInfoListReturnForXmlRpc getAllTasksInfo() {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc stopTask(String taskUUID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc clearTask(String taskUUID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc revertTask(String taskUUID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc hotplugDisk(Map info) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc hotunplugDisk(Map info) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc hotPlugNic(Map info) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc hotUnplugNic(Map info) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc vmUpdateDevice(String vmId, Map device) {
+        return null;
+    }
+
+    @Override
+    public FutureTask<Map<String, Object>> poll() {
+        return null;
+    }
+
+    @Override
+    public FutureTask<Map<String, Object>> timeBoundPoll(long timeout, TimeUnit unit) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc snapshot(String vmId, Map<String, String>[] disks) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc snapshot(String vmId, Map<String, String>[] disks, String memory) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc snapshot(String vmId, Map<String, String>[] disks, String memory, boolean frozen) {
+        return null;
+    }
+
+    @Override
+    public AlignmentScanReturnForXmlRpc getDiskAlignment(String vmId, Map<String, String> driveSpecs) {
+        return null;
+    }
+
+    @Override
+    public ImageSizeReturnForXmlRpc diskSizeExtend(String vmId, Map<String, String> diskParams, String newSize) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc merge(String vmId,
+            Map<String, String> drive,
+            String baseVolUUID,
+            String topVolUUID,
+            String bandwidth,
+            String jobUUID) {
+        return null;
+    }
+
+    @Override
+    public OneUuidReturnForXmlRpc glusterVolumeCreate(String volumeName,
+            String[] brickList,
+            int replicaCount,
+            int stripeCount,
+            String[] transportList) {
+        return null;
+    }
+
+    @Override
+    public OneUuidReturnForXmlRpc glusterVolumeCreate(String volumeName,
+            String[] brickList,
+            int replicaCount,
+            int stripeCount,
+            String[] transportList,
+            boolean force) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeSet(String volumeName, String key, String value) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeStart(String volumeName, Boolean force) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeStop(String volumeName, Boolean force) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeDelete(String volumeName) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeReset(String volumeName, String volumeOption, Boolean force) {
+        return null;
+    }
+
+    @Override
+    public GlusterVolumeOptionsInfoReturnForXmlRpc glusterVolumeSetOptionsList() {
+        return null;
+    }
+
+    @Override
+    public GlusterTaskInfoReturnForXmlRpc glusterVolumeRemoveBricksStart(String volumeName,
+            String[] brickList,
+            int replicaCount,
+            Boolean forceRemove) {
+        return null;
+    }
+
+    @Override
+    public GlusterVolumeTaskReturnForXmlRpc glusterVolumeRemoveBricksStop(String volumeName,
+            String[] brickList,
+            int replicaCount) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeRemoveBricksCommit(String volumeName,
+            String[] brickList,
+            int replicaCount) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeBrickAdd(String volumeName,
+            String[] bricks,
+            int replicaCount,
+            int stripeCount) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeBrickAdd(String volumeName,
+            String[] bricks,
+            int replicaCount,
+            int stripeCount,
+            boolean force) {
+        return null;
+    }
+
+    @Override
+    public GlusterTaskInfoReturnForXmlRpc glusterVolumeRebalanceStart(String volumeName,
+            Boolean fixLayoutOnly,
+            Boolean force) {
+        return null;
+    }
+
+    @Override
+    public GlusterVolumeTaskReturnForXmlRpc glusterVolumeRebalanceStop(String volumeName) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeReplaceBrickStart(String volumeName,
+            String existingBrickDir,
+            String newBrickDir) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterHostRemove(String hostName, Boolean force) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterHostAdd(String hostName) {
+        return null;
+    }
+
+    @Override
+    public GlusterServersListReturnForXmlRpc glusterServersList() {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc diskReplicateStart(String vmUUID, Map srcDisk, Map dstDisk) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc diskReplicateFinish(String vmUUID, Map srcDisk, Map dstDisk) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeProfileStart(String volumeName) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeProfileStop(String volumeName) {
+        return null;
+    }
+
+    @Override
+    public GlusterVolumeStatusReturnForXmlRpc glusterVolumeStatus(Guid clusterId,
+            String volumeName,
+            String brickName,
+            String volumeStatusOption) {
+        return null;
+    }
+
+    @Override
+    public GlusterVolumesListReturnForXmlRpc glusterVolumesList(Guid clusterId) {
+        return null;
+    }
+
+    @Override
+    public GlusterVolumeProfileInfoReturnForXmlRpc glusterVolumeProfileInfo(Guid clusterId,
+            String volumeName,
+            boolean nfs) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterHookEnable(String glusterCommand, String stage, String hookName) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterHookDisable(String glusterCommand, String stage, String hookName) {
+        return null;
+    }
+
+    @Override
+    public GlusterHooksListReturnForXmlRpc glusterHooksList() {
+        return null;
+    }
+
+    @Override
+    public OneUuidReturnForXmlRpc glusterHostUUIDGet() {
+        return null;
+    }
+
+    @Override
+    public GlusterServicesReturnForXmlRpc glusterServicesList(Guid serverId, String[] serviceNames) {
+        return null;
+    }
+
+    @Override
+    public GlusterHookContentInfoReturnForXmlRpc glusterHookRead(String glusterCommand, String stage, String hookName) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterHookUpdate(String glusterCommand,
+            String stage,
+            String hookName,
+            String content,
+            String checksum) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterHookAdd(String glusterCommand,
+            String stage,
+            String hookName,
+            String content,
+            String checksum,
+            Boolean enabled) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterHookRemove(String glusterCommand, String stage, String hookName) {
+        return null;
+    }
+
+    @Override
+    public GlusterServicesReturnForXmlRpc glusterServicesAction(Guid serverId,
+            String[] serviceList,
+            String actionType) {
+        return null;
+    }
+
+    @Override
+    public StoragePoolInfoReturnForXmlRpc getStoragePoolInfo(String spUUID) {
+        return null;
+    }
+
+    @Override
+    public GlusterTasksListReturnForXmlRpc glusterTasksList() {
+        return null;
+    }
+
+    @Override
+    public GlusterVolumeTaskReturnForXmlRpc glusterVolumeRebalanceStatus(String volumeName) {
+        return null;
+    }
+
+    @Override
+    public BooleanReturnForXmlRpc glusterVolumeEmptyCheck(String volumeName) {
+        return null;
+    }
+
+    @Override
+    public GlusterHostsPubKeyReturnForXmlRpc glusterGeoRepKeysGet() {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterGeoRepKeysUpdate(List<String> geoRepPubKeys, String userName) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterGeoRepMountBrokerSetup(String remoteVolumeName,
+            String userName,
+            String remoteGroupName,
+            Boolean partial) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeGeoRepSessionCreate(String volumeName,
+            String remoteHost,
+            String remoteVolumeName,
+            String userName,
+            Boolean force) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeGeoRepSessionDelete(String volumeName,
+            String remoteHost,
+            String remoteVolumeName,
+            String userName) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeGeoRepSessionStop(String volumeName,
+            String remoteHost,
+            String remoteVolumeName,
+            String userName,
+            Boolean force) {
+        return null;
+    }
+
+    @Override
+    public GlusterVolumeGeoRepStatusForXmlRpc glusterVolumeGeoRepSessionList() {
+        return null;
+    }
+
+    @Override
+    public GlusterVolumeGeoRepStatusForXmlRpc glusterVolumeGeoRepSessionList(String volumeName) {
+        return null;
+    }
+
+    @Override
+    public GlusterVolumeGeoRepStatusForXmlRpc glusterVolumeGeoRepSessionList(String volumeName,
+            String slaveHost,
+            String slaveVolumeName,
+            String userName) {
+        return null;
+    }
+
+    @Override
+    public GlusterVolumeGeoRepStatusDetailForXmlRpc glusterVolumeGeoRepSessionStatus(String volumeName,
+            String slaveHost,
+            String slaveVolumeName,
+            String userName) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeGeoRepSessionStart(String volumeName,
+            String remoteHost,
+            String remoteVolumeName,
+            String userName,
+            Boolean force) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeGeoRepSessionPause(String masterVolumeName,
+            String slaveHost,
+            String slaveVolumeName,
+            String userName,
+            boolean force) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeGeoRepConfigSet(String volumeName,
+            String slaveHost,
+            String slaveVolumeName,
+            String configKey,
+            String configValue,
+            String userName) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeGeoRepConfigReset(String volumeName,
+            String slaveHost,
+            String slaveVolumeName,
+            String configKey,
+            String userName) {
+        return null;
+    }
+
+    @Override
+    public GlusterVolumeGeoRepConfigListXmlRpc glusterVolumeGeoRepConfigList(String volumeName,
+            String slaveHost,
+            String slaveVolumeName,
+            String userName) {
+        return null;
+    }
+
+    @Override
+    public GlusterVolumeTaskReturnForXmlRpc glusterVolumeRemoveBrickStatus(String volumeName, String[] bricksList) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc setNumberOfCpus(String vmId, String numberOfCpus) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc hotplugMemory(Map info) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc updateVmPolicy(Map info) {
+        return null;
+    }
+
+    @Override
+    public VMListReturnForXmlRpc getExternalVmList(String uri, String username, String password) {
+        return null;
+    }
+
+    @Override
+    public OneVmReturnForXmlRpc getExternalVmFromOva(String ovaPath) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeGeoRepSessionResume(String volumeName,
+            String slaveHostName,
+            String slaveVolumeName,
+            String userName,
+            boolean force) {
+        return null;
+    }
+
+    @Override
+    public GlusterVolumeSnapshotInfoReturnForXmlRpc glusterVolumeSnapshotList(Guid clusterId, String volumeName) {
+        return null;
+    }
+
+    @Override
+    public GlusterVolumeSnapshotConfigReturnForXmlRpc glusterSnapshotConfigList(Guid clusterId) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterSnapshotDelete(String snapshotName) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeSnapshotDeleteAll(String volumeName) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterSnapshotActivate(String snapshotName, boolean force) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterSnapshotDeactivate(String snapshotName) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterSnapshotRestore(String snapshotName) {
+        return null;
+    }
+
+    @Override
+    public GlusterVolumeSnapshotCreateReturnForXmlRpc glusterVolumeSnapshotCreate(String volumeName,
+            String snapshotName,
+            String description,
+            boolean force) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterVolumeSnapshotConfigSet(String volumeName,
+            String cfgName,
+            String cfgValue) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterSnapshotConfigSet(String cfgName, String cfgValue) {
+        return null;
+    }
+
+    @Override
+    public OneStorageDeviceReturnForXmlRpc glusterCreateBrick(String lvName,
+            String mountPoint,
+            Map<String, Object> raidParams,
+            String fsType,
+            String[] storageDevices) {
+        return null;
+    }
+
+    @Override
+    public StorageDeviceListReturnForXmlRpc glusterStorageDeviceList() {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc hostdevChangeNumvfs(String deviceName, int numOfVfs) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc convertVmFromExternalSystem(String url,
+            String user,
+            String password,
+            Map<String, Object> vm,
+            String jobUUID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc convertVmFromOva(String ovaPath, Map<String, Object> vm, String jobUUID) {
+        return null;
+    }
+
+    @Override
+    public OvfReturnForXmlRpc getConvertedVm(String jobUUID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc deleteV2VJob(String jobUUID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc abortV2VJob(String jobUUID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterSnapshotScheduleOverride(boolean force) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterSnapshotScheduleReset() {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc registerSecrets(Map<String, String>[] libvirtSecrets, boolean clearUnusedSecrets) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc unregisterSecrets(String[] libvirtSecretsUuids) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc freeze(String vmId) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc thaw(String vmId) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc isolateVolume(String sdUUID,
+            String srcImageID,
+            String dstImageID,
+            String volumeID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc wipeVolume(String sdUUID, String imgUUID, String volUUID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc refreshVolume(String sdUUID, String spUUID, String imgUUID, String volUUID) {
+        return null;
+    }
+
+    @Override
+    public VolumeInfoReturnForXmlRpc getVolumeInfo(String sdUUID, String spUUID, String imgUUID, String volUUID) {
+        return null;
+    }
+
+    @Override
+    public StatusOnlyReturnForXmlRpc glusterStopProcesses() {
+        return null;
+    }
+}

--- a/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/kubevirt/ServiceDiscovery.java
+++ b/backend/manager/modules/vdsbroker/src/main/java/org/ovirt/engine/core/vdsbroker/vdsbroker/kubevirt/ServiceDiscovery.java
@@ -1,0 +1,29 @@
+package org.ovirt.engine.core.vdsbroker.vdsbroker.kubevirt;
+
+import javax.validation.constraints.NotNull;
+
+import org.ovirt.engine.core.compat.Guid;
+
+/**
+ * For now this class is only responsible for providing a HTTP URL to a service. In the future this would return a
+ * prepared HTTP request which already has the right credentials set and is ready to use.
+ */
+public interface ServiceDiscovery {
+
+    /**
+     * Look up a system wide service
+     *
+     * @param serviceName System wide name of the service
+     * @return Service HTTP connection URL
+     */
+    public String discover(@NotNull String serviceName);
+
+    /**
+     * Look up a service running on a specific host/node. Most likely you want a service out of a daemon set.
+     *
+     * @param serviceName Service name
+     * @param vdsId       Id of the host/node where we need the service from
+     * @return
+     */
+    public String discover(@NotNull String serviceName, Guid vdsId);
+}


### PR DESCRIPTION
## Basic requirements
- [x]  Add environment variable based kubernetes service discovery
- [x]  Allow adding kubevirt managed hosts (all hosts having a name starting with 'kubevirt' are kubevirt managed hosts

- [ ]  Implement host capabilities/health check based on cAdvisor (so that the host is up)
- [ ]  Implement VM create call by posting to the kubevirt controller

## Bonus
- [ ]  Implement VM stats call by querying prometheus (prometheus gets the data from vAdvisor)
- [ ]  Implement VM list call by querying vAdvisor

- [ ]  Allow setting the host manager from the UI instead of parsing the host name